### PR TITLE
Purge ruby-build dirs before installing

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,6 +16,12 @@ class ruby_build(
     require  =>  Class['git'],
   }
 
+  file { [ "${prefix}/share/ruby-build", "${prefix}/bin/ruby-build" ]:
+    ensure => absent,
+    force  => true,
+    before => Exec['install ruby-build'],
+  }
+
   exec { 'install ruby-build':
     cwd         => "${source_root}/ruby-build",
     command     => "${source_root}/ruby-build/install.sh",


### PR DESCRIPTION
This commit adds file resources for `${prefix}/share/ruby-build` and
`${prefix}/bin/ruby-build` to ensure that they are removed prior to
running the `install ruby-build` Exec.

The ruby-build install script does not update properly update
the installation when rerunning it. Before this commit, changing
the version for the `ruby_build` class would correctly update the
git checkout in staging, but the install script would not copy
all of the expected bits into the install dirs.

This commit ensures that the previous install bits are removed
before running the `install ruby-build` Exec. This allows the
install script to properly install all of the artifacts associated
with the code in the define version of the git repo.
