### PR TITLE
Exempt git management on OS X

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,13 @@ class ruby_build(
   $prefix      = '/usr/local'
 ) {
 
-  require 'git'
+  if ( $::osfamily == 'Darwin' ) {
+    $git_manage = false
+  } else {
+    $git_manage = true
+  }
+  class { 'git': package_manage => $git_manage, }
+  contain 'git'
 
   # Pull down and install a tool to build our dev version of Ruby
   vcsrepo { 'ruby-build':


### PR DESCRIPTION
The puppetlabs-git module does not allow specification of a
source for the git package. A source is required on OS X by
the package resource. So, the puppetlabs-git module cannot
manage git packages on OS X.

This commit sets the `manage_package` parameter of the
puppetlabs-git class to `false`. This allows ruby-build to
install on OS X, but assumes that the user has installed git
on their own.
