### PR TITLE
Add params for dev dependencies

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,8 +1,9 @@
 class ruby_build(
   $version     = '9cd77be141e066b968b4a7e72d0628c671e067e4',
   $source_root = '/opt/puppet_staging/sources',
-  $prefix      = '/usr/local'
-) {
+  $prefix      = '/usr/local',
+  $dev_packages = $ruby_build::params::dev_packages,
+) inherits ruby_build::params {
 
   if ( $::osfamily == 'Darwin' ) {
     $git_manage = false
@@ -11,6 +12,7 @@ class ruby_build(
   }
   class { 'git': package_manage => $git_manage, }
   contain 'git'
+  ensure_packages($dev_packages)
 
   # Pull down and install a tool to build our dev version of Ruby
   vcsrepo { 'ruby-build':

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,21 @@
+#
+class ruby_build::params {
+  case $::osfamily {
+    'RedHat': {
+      $dev_packages = [ 'ruby-devel',
+              'libxml2-devel', 'libxslt-devel',
+              'openssl-devel', 'readline-devel',
+              'gcc', 'gcc-c++' ]
+    }
+    'Debian': {
+      $dev_packages = [ 'ruby-dev',
+              'libxml2-dev', 'libxslt1-dev',
+              'libreadline-dev',
+              'libssl-dev', 'zlib1g-dev',
+              'gcc', 'g++', 'make' ]
+    }
+    default: {
+      $dev_packages = [ ]
+    }
+  }
+}


### PR DESCRIPTION
This commit adds a params class to the module. The required package dependencies for the RedHat and Debian to be able to compile rubies are added to be used as `$ruby_build::params::dev_packages`.

The `ruby_build` class has been updated to use this parameter and ensures that these packages are installed.
