### PR TITLE
Add bzip2 as a dev dependency

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,14 +5,14 @@ class ruby_build::params {
       $dev_packages = [ 'ruby-devel',
               'libxml2-devel', 'libxslt-devel',
               'openssl-devel', 'readline-devel',
-              'gcc', 'gcc-c++' ]
+              'gcc', 'gcc-c++', 'bzip2' ]
     }
     'Debian': {
       $dev_packages = [ 'ruby-dev',
               'libxml2-dev', 'libxslt1-dev',
               'libreadline-dev',
               'libssl-dev', 'zlib1g-dev',
-              'gcc', 'g++', 'make' ]
+              'gcc', 'g++', 'make', 'bzip2' ]
     }
     default: {
       $dev_packages = [ ]


### PR DESCRIPTION
This commit adds bzip2 as a dev dependency for el and debian.
